### PR TITLE
Update base image and PowerShell.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/ubuntu:focal-20220404
+FROM quay.io/bedrock/ubuntu:focal-20220426
 
 # increment the number in this file to force a full container rebuild
 COPY files/update.txt /dev/null


### PR DESCRIPTION
This will also pull in the latest Python 3.11.0 beta release.