### PR TITLE
Remove the VOLUME instruction.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM quay.io/bedrock/ubuntu:focal-20220801
 
-VOLUME /sys/fs/cgroup /run/lock /run /tmp
-
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
This instruction introduces two issues:

1. Each volume becomes an anonymous volume when the container is run.
   These volumes are not automatically removed unless the `--rm` option is used.
   Instead, create temporary volumes with the `--tmpfs` or `--mount` option, as needed.
2. Specifying a `/sys/fs/cgroup` volume interferes with systemd support.
   The anonymous volume overrides the cgroup mount under both docker and podman.