### PR TITLE
Improve PowerShell install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,18 +64,23 @@ RUN rm /etc/apt/apt.conf.d/docker-clean && \
 
 # Install PowerShell using a binary archive.
 # This allows pinning to a specific version, and also brings support for multiple architectures.
-RUN arch="$(uname -i)" && \
+RUN version="7.2.6" && \
+    major_version="$(echo ${version} | cut -f 1 -d .)" && \
+    install_dir="/opt/microsoft/powershell/${major_version}" && \
+    tmp_file="/tmp/powershell.tgz" && \
+    arch="$(uname -i)" && \
     arch=$(if [ "${arch}" = "x86_64" ]; then echo "x64"; \
          elif [ "${arch}" = "aarch64" ]; then echo "arm64"; \
          else echo "unknown arch: ${arch}" && exit 1; fi) && \
-    url="https://github.com/PowerShell/PowerShell/releases/download/v7.2.4/powershell-7.2.4-linux-${arch}.tar.gz" && \
+    url="https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-linux-${arch}.tar.gz" && \
     echo "URL: ${url}" && \
-    curl -sL "${url}" > /tmp/powershell.tgz && \
-    mkdir -p /opt/microsoft/powershell/7 && \
-    tar zxf /tmp/powershell.tgz -C /opt/microsoft/powershell/7 && \
-    rm /tmp/powershell.tgz && \
-    chmod +x /opt/microsoft/powershell/7/pwsh && \
-    ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh && \
+    curl -sL "${url}" > "${tmp_file}" && \
+    mkdir -p "${install_dir}" && \
+    tar zxf "${tmp_file}" --no-same-owner --no-same-permissions -C "${install_dir}" && \
+    rm "${tmp_file}" && \
+    find "${install_dir}" -type f -exec chmod -x "{}" ";" && \
+    chmod +x "${install_dir}/pwsh" && \
+    ln -s "${install_dir}/pwsh" /usr/bin/pwsh && \
     pwsh --version
 
 ENV container=docker


### PR DESCRIPTION
- Upgrade from PowerShell 7.2.4 to 7.2.6.
- Reduce repeated use of hardcoded values.
- Fix ownership and permissions of extracted PowerShell files.