### PR TITLE
Include sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update -y && \
     python3.9-distutils \
     python3.9-venv \
     shellcheck \
+    sudo \
     systemd-sysv \
     && \
     apt-get clean && \


### PR DESCRIPTION
This allows more integration tests to run unmodified using the default containers.