### PR TITLE
Revert "Use Python 3.12 for the container setup (#28)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ CMD ["/sbin/init"]
 
 # Install pip last to speed up local container rebuilds.
 COPY files/*.py /usr/share/container-setup/
-RUN ln -s /usr/bin/python3.12 /usr/share/container-setup/python
+RUN ln -s /usr/bin/python3.11 /usr/share/container-setup/python
 RUN /usr/share/container-setup/python -B /usr/share/container-setup/setup.py
 
 # Make sure the pip entry points in /usr/bin are correct.


### PR DESCRIPTION
This reverts commit fe6db9142b0e4926b6a465b84fc2c11a0d652b8f.

This change shouldn't have been merged yet. The Python version used here needs to match the default used by ansible-test. That's determined by the first Python version listed here:

https://github.com/ansible/ansible/blob/48dfe8e21524a84e87d4d1f6ec49edb9c2d7c68c/test/lib/ansible_test/_data/completion/docker.txt#L1-L3

That's because this Python version determines what is used to prime the sanity test virtual environments.

@s-hertel I overlooked this when I approved merging of https://github.com/ansible/base-test-container/pull/28/ -- sorry about that.