### PR TITLE
Update the base image to Ubuntu 22.04

### DIFF
--- a/files/deadsnakes.list
+++ b/files/deadsnakes.list
@@ -1,2 +1,2 @@
-deb [signed-by=/etc/apt/keyrings/deadsnakes.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main
-deb-src [signed-by=/etc/apt/keyrings/deadsnakes.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main
+deb [signed-by=/etc/apt/keyrings/deadsnakes.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main
+deb-src [signed-by=/etc/apt/keyrings/deadsnakes.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main


### PR DESCRIPTION
Other updates included:

* Upgrade from PowerShell 7.3.8 to 7.4.0 (includes .NET 8.0.0)
* Clean up and better document the container build
* Omit `pip` from `/usr/bin` (it's still in `/usr/local/bin`)